### PR TITLE
Adds the option to save on other events, such as Cordova's onpause

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-storage-decorator-debounce",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Delay and merge save opertations of redux-storage",
   "main": "build/index.js",
   "scripts": {

--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -65,6 +65,19 @@ describe('debounce', () => {
         }, 25);
     });
 
+    it('should save early on other events', (done) => {
+        const save = sinon.stub().resolves();
+        const engine = debounce({ save }, 500, null, ['onpause']);
+
+        engine.save({});
+        window.dispatchEvent('onpause');
+
+        setTimeout(() => {
+            save.should.have.been.calledOnce;
+            done();
+        }, 25);
+    });
+
     it('should not self-trigger save on beforeunload', (done) => {
         const save = sinon.stub().resolves();
         debounce({ save }, 0);

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export default (engine, ms, maxWait = null) => {
+export default (engine, ms, maxWait = null, eventsToPersistOn = ['beforeunload']) => {
     if (maxWait !== null && ms > maxWait) {
         throw new Error('maxWait must be > ms');
     }
@@ -15,7 +15,7 @@ export default (engine, ms, maxWait = null) => {
         // ignore error
     }
     if (hasWindow && window.addEventListener) {
-        window.addEventListener('beforeunload', () => {
+        const saveUponEvent = () => {
             if (!lastTimeout) {
                 return;
             }
@@ -24,7 +24,8 @@ export default (engine, ms, maxWait = null) => {
             maxTimeout = clearTimeout(maxTimeout);
             lastReject = null;
             engine.save(lastState);
-        });
+        };
+        eventsToPersistOn.forEach(eventName => window.addEventListener(eventName, saveUponEvent));
     }
 
     return {


### PR DESCRIPTION
Adds the option to save on other events, such as Cordova's `onpause`.
The change is backwards compatible, current users should not be affected.